### PR TITLE
Make ultralytics work properly in codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,7 @@
 	"features": {},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install -r requirements.txt",
-	// install OpenGL libraries
-	"postCreateCommand": "sudo apt update && sudo apt install libgl1-mesa-glx -y",
+	"postCreateCommand": "pip install -r requirements.txt && sudo apt update && sudo apt install libgl1-mesa-glx -y",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,8 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pip install -r requirements.txt",
+	// install OpenGL libraries
+	"postCreateCommand": "sudo apt update && sudo apt install libgl1-mesa-glx -y",
 
 	// Configure tool-specific properties.
 	"customizations": {


### PR DESCRIPTION
This fixes an error due to missing OpenGL dynamically-linked libraries when trying to `import ultralytics` inside codespaces.